### PR TITLE
react to lage having the `latest` tag default to 0.x

### DIFF
--- a/cospace/package.json
+++ b/cospace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cospace",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Setup a `CoSpace` to link multiple (mono)repos together!",
   "author": "https://github.com/aruniverse",
   "license": "MIT",

--- a/cospace/template/package.json
+++ b/cospace/template/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "cospace": "latest",
-    "lage": "latest"
+    "lage": "^1.5.1"
   },
   "pnpm": {
     "overrides": {},


### PR DESCRIPTION
React to change made here, https://github.com/microsoft/lage/commit/a83120f54edad9526205765c7006d240772ef798